### PR TITLE
use boost::shared_ptr to avoid problems with c++11

### DIFF
--- a/Cifti/CiftiXML.cxx
+++ b/Cifti/CiftiXML.cxx
@@ -55,7 +55,7 @@ void CiftiXML::copyHelper(const CiftiXML& rhs)
     m_indexMaps.resize(numDims);
     for (int i = 0; i < numDims; ++i)
     {
-        m_indexMaps[i] = shared_ptr<CiftiMappingType>(rhs.m_indexMaps[i]->clone());
+        m_indexMaps[i] = boost::shared_ptr<CiftiMappingType>(rhs.m_indexMaps[i]->clone());
     }
     m_parsedVersion = rhs.m_parsedVersion;
     m_fileMetaData = rhs.m_fileMetaData;
@@ -204,7 +204,7 @@ CiftiMappingType::MappingType CiftiXML::getMappingType(const int& direction) con
 void CiftiXML::setMap(const int& direction, const CiftiMappingType& mapIn)
 {
     CiftiAssertVectorIndex(m_indexMaps, direction);
-    m_indexMaps[direction] = shared_ptr<CiftiMappingType>(mapIn.clone());
+    m_indexMaps[direction] = boost::shared_ptr<CiftiMappingType>(mapIn.clone());
 }
 
 void CiftiXML::setNumberOfDimensions(const int& num)
@@ -771,19 +771,19 @@ void CiftiXML::parseMatrixIndicesMap1(XmlReader& xml)
         }
         used.insert(parsed);
     }
-    shared_ptr<CiftiMappingType> toRead;
+    boost::shared_ptr<CiftiMappingType> toRead;
     AString type = myAttrs.mandatoryVals[1];
     if (type == "CIFTI_INDEX_TYPE_BRAIN_MODELS")
     {
-        toRead = shared_ptr<CiftiBrainModelsMap>(new CiftiBrainModelsMap());
+        toRead = boost::shared_ptr<CiftiBrainModelsMap>(new CiftiBrainModelsMap());
     } else if (type == "CIFTI_INDEX_TYPE_TIME_POINTS") {
-        toRead = shared_ptr<CiftiSeriesMap>(new CiftiSeriesMap());
+        toRead = boost::shared_ptr<CiftiSeriesMap>(new CiftiSeriesMap());
     } else if (type == "CIFTI_INDEX_TYPE_LABELS") {//this and below are nonstandard
-        toRead = shared_ptr<CiftiLabelsMap>(new CiftiLabelsMap());
+        toRead = boost::shared_ptr<CiftiLabelsMap>(new CiftiLabelsMap());
     } else if (type == "CIFTI_INDEX_TYPE_PARCELS") {
-        toRead = shared_ptr<CiftiParcelsMap>(new CiftiParcelsMap());
+        toRead = boost::shared_ptr<CiftiParcelsMap>(new CiftiParcelsMap());
     } else if (type == "CIFTI_INDEX_TYPE_SCALARS") {
-        toRead = shared_ptr<CiftiScalarsMap>(new CiftiScalarsMap());
+        toRead = boost::shared_ptr<CiftiScalarsMap>(new CiftiScalarsMap());
     } else {
         throw CiftiException("invalid value for IndicesMapToDataType in CIFTI-1: " + type);
     }
@@ -801,7 +801,7 @@ void CiftiXML::parseMatrixIndicesMap1(XmlReader& xml)
             m_indexMaps[*iter] = toRead;
             first = false;
         } else {
-            m_indexMaps[*iter] = shared_ptr<CiftiMappingType>(toRead->clone());//make in-memory information independent per-dimension, rather than dealing with deduplication everywhere
+            m_indexMaps[*iter] = boost::shared_ptr<CiftiMappingType>(toRead->clone());//make in-memory information independent per-dimension, rather than dealing with deduplication everywhere
         }
     }
     CiftiAssert(XmlReader_checkEndElement(xml, "MatrixIndicesMap"));
@@ -829,19 +829,19 @@ void CiftiXML::parseMatrixIndicesMap2(XmlReader& xml)
         }
         used.insert(parsed);
     }
-    shared_ptr<CiftiMappingType> toRead;
+    boost::shared_ptr<CiftiMappingType> toRead;
     AString type = myAttrs.mandatoryVals[1];
     if (type == "CIFTI_INDEX_TYPE_BRAIN_MODELS")
     {
-        toRead = shared_ptr<CiftiBrainModelsMap>(new CiftiBrainModelsMap());
+        toRead = boost::shared_ptr<CiftiBrainModelsMap>(new CiftiBrainModelsMap());
     } else if (type == "CIFTI_INDEX_TYPE_LABELS") {
-        toRead = shared_ptr<CiftiLabelsMap>(new CiftiLabelsMap());
+        toRead = boost::shared_ptr<CiftiLabelsMap>(new CiftiLabelsMap());
     } else if (type == "CIFTI_INDEX_TYPE_PARCELS") {
-        toRead = shared_ptr<CiftiParcelsMap>(new CiftiParcelsMap());
+        toRead = boost::shared_ptr<CiftiParcelsMap>(new CiftiParcelsMap());
     } else if (type == "CIFTI_INDEX_TYPE_SCALARS") {
-        toRead = shared_ptr<CiftiScalarsMap>(new CiftiScalarsMap());
+        toRead = boost::shared_ptr<CiftiScalarsMap>(new CiftiScalarsMap());
     } else if (type == "CIFTI_INDEX_TYPE_SERIES") {
-        toRead = shared_ptr<CiftiSeriesMap>(new CiftiSeriesMap());
+        toRead = boost::shared_ptr<CiftiSeriesMap>(new CiftiSeriesMap());
     } else {
         throw CiftiException("invalid value for IndicesMapToDataType in CIFTI-1: " + type);
     }
@@ -859,7 +859,7 @@ void CiftiXML::parseMatrixIndicesMap2(XmlReader& xml)
             m_indexMaps[*iter] = toRead;
             first = false;
         } else {
-            m_indexMaps[*iter] = shared_ptr<CiftiMappingType>(toRead->clone());//make in-memory information independent per-dimension, rather than dealing with deduplication everywhere
+            m_indexMaps[*iter] = boost::shared_ptr<CiftiMappingType>(toRead->clone());//make in-memory information independent per-dimension, rather than dealing with deduplication everywhere
         }
     }
     CiftiAssert(XmlReader_checkEndElement(xml, "MatrixIndicesMap"));

--- a/Common/BinaryFile.cxx
+++ b/Common/BinaryFile.cxx
@@ -141,15 +141,15 @@ void BinaryFile::open(const AString& filename, const OpenMode& opmode)
     if (AString_substr(filename, filename.size() - 3) == ".gz")
     {
 #ifdef ZLIB_VERSION
-        m_impl = shared_ptr<ZFileImpl>(new ZFileImpl());
+        m_impl = boost::shared_ptr<ZFileImpl>(new ZFileImpl());
 #else //ZLIB_VERSION
         throw CiftiException("can't open .gz file '" + filename + "', compiled without zlib support");
 #endif //ZLIB_VERSION
     } else {
 #ifdef CIFTILIB_USE_QT
-        m_impl = shared_ptr<QFileImpl>(new QFileImpl());
+        m_impl = boost::shared_ptr<QFileImpl>(new QFileImpl());
 #else
-        m_impl = shared_ptr<StrFileImpl>(new StrFileImpl());
+        m_impl = boost::shared_ptr<StrFileImpl>(new StrFileImpl());
 #endif
     }
     m_impl->open(filename, opmode);

--- a/Nifti/NiftiHeader.cxx
+++ b/Nifti/NiftiHeader.cxx
@@ -500,7 +500,7 @@ void NiftiHeader::read(BinaryFile& inFile)
             inFile.read(&ecode, sizeof(int32_t));
             if (swapped) ByteSwapping::swap(ecode);
             if (esize < 8 || esize + extStart > m_header.vox_offset) break;
-            shared_ptr<NiftiExtension> tempExtension(new NiftiExtension());
+            boost::shared_ptr<NiftiExtension> tempExtension(new NiftiExtension());
             if ((size_t)esize > 2 * sizeof(int32_t))//don't try to read 0 bytes
             {
                 tempExtension->m_bytes.resize(esize - 2 * sizeof(int32_t));


### PR DESCRIPTION
Reference: https://github.com/Washington-University/CiftiLib/issues/1
Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
