### PR TITLE
Place documentation output inside the source tree.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -52,7 +52,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location 
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ../doxygen
+OUTPUT_DIRECTORY       = doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 
 # 4096 sub-directories (in 2 levels) under the output directory of each output 


### PR DESCRIPTION
There is not guarantee that `../doxygen` is user-writable, so this setting is fragile. Instead use a location inside the source tree.
