### PR TITLE
Provide openmp flag in .pc file if used.

### DIFF
--- a/CiftiLib.pc.in
+++ b/CiftiLib.pc.in
@@ -5,6 +5,6 @@ Name: CiftiLib
 Description: C++ Library for reading and writing CIFTI-2 and CIFTI-1 files
 Version: @CIFTILIB_VERSION@
 URL: https://github.com/Washington-University/CiftiLib
-Cflags: -I${includedir}/CiftiLib @CIFTILIB_PKGCONFIG_DEFINE@
+Cflags: -I${includedir}/CiftiLib @CIFTILIB_PKGCONFIG_DEFINE@ @OpenMP_CXX_FLAGS@
 Libs: -L${libdir} -lCifti
 @CIFTILIB_PKGCONFIG_REQUIRES_LINE@


### PR DESCRIPTION
When CiftiLib is compiled with openmp the resulting library will depend on openmp libraries. Which means that when you link with the libCifti you need to provide openmp libraries or instructions to link with openmp libraries.

In the case of gcc/g++ passing `-fopenmp` to the compiler when linking is sufficient. Alternatively you would use `-lgomp`. With this branch the openmp flags are added to the cflags (if openmp is not available it will be as before). If you use that cflags at linking stage (as you should) the compiler should link properly with the appropriate openmp libraries.